### PR TITLE
Fix sign up data

### DIFF
--- a/api.py
+++ b/api.py
@@ -37,7 +37,12 @@ class UserResource:
             raise falcon.HTTPMissingParam(password_post_field)
         new_data = None #optional
         if data_post_field in req.params:
-            new_data = req.params[data_post_field]
+            # Falcon has special handling of commas in post data,
+            # our JSON text may be split on any commas into list of str
+            falcon_data = req.params[data_post_field]
+            new_data = falcon_data # default, assume text is unmangled
+            if isinstance(falcon_data, list): #text was munged
+                new_data = ','.join(falcon_data)#merge strings & add commas back in
         # securely hash user password & attempt to add new user
         new_hash = user.hash_password(request_password)
         with user_storage.get_session() as storage_session:

--- a/test_api.py
+++ b/test_api.py
@@ -77,6 +77,24 @@ class TestUser(TestApi):
         with self.assertRaises(Exception):
             double_result = self.simulate_post(user_url, params = test_params)
 
+        # test optional JSON sign up data (with comma characters in it)
+        signup_url = '/user' # sign up a user
+        test_json = '{"address":"1 Microsoft Way", "phone":"1-555-555-5555"}'
+        test_params = {'username': 'salvador.dali', 'password': 'secret1', 'data': test_json}
+        result = self.simulate_post(signup_url, params = test_params)
+        self.assertEqual(result.status_code, 200) # OK
+        # log in
+        auth_url = '/auth'
+        result = self.simulate_post(auth_url, params = test_params)
+        session_token, expire_info = result.headers['set-cookie'].lstrip().split(';', 1)
+
+        # get data, with session token
+        user_url = '/user/salvador.dali'
+        expected = {'data': {'address': '1 Microsoft Way', 'phone': '1-555-555-5555'},
+                    'username': 'salvador.dali'} #data should be dict, not array of str
+        result = self.simulate_get(user_url, headers={'Cookie': session_token})
+        self.assertEqual(result.json, expected)
+
     def test_put(self):
         user_url = '/user/pat.ng'
         # no login session


### PR DESCRIPTION
Corrects issue #1, fixing the conflict where Falcon's `auto_parse_form_urlencoded` Request option parse feature was handling JSON text incorrectly.

Adds test coverage for sign up when optional JSON data contains commas.